### PR TITLE
Npm version failsafe

### DIFF
--- a/build/scripts/configure.sh
+++ b/build/scripts/configure.sh
@@ -8,6 +8,21 @@
 set -e
 . build/scripts/conf.sh
 
+# Check if NPM is proper version
+MINIMUM_NPM_VERSION="6.0.0"
+CURRENT_NPM_VERSION=$(npm -v)
+
+
+version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != $
+if version_check $CURRENT_NPM_VERSION $MINIMUM_NPM_VERSION; then
+        echo "[ERROR] NPM version '$CURRENT_NPM_VERSION' is below requirement of '$MINIMUM_NPM_VERSION'"
+        echo "[ERROR] Please install an updated version and run npm install again"
+	echo "[ERROR] See the README for details"
+        exit 1;
+fi
+
+
+
 read -p 'Document root (DEF: /var/www): ' ICONF_DOCROOT;
 if [ -z "$ICONF_DOCROOT" ]; then
 	ICONF_DOCROOT='/var/www';

--- a/build/scripts/configure.sh
+++ b/build/scripts/configure.sh
@@ -16,7 +16,7 @@ CURRENT_NPM_VERSION=$(npm -v)
 version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
 if version_check $CURRENT_NPM_VERSION $MINIMUM_NPM_VERSION; then
         echo "[ERROR] NPM version '$CURRENT_NPM_VERSION' is below requirement of '$MINIMUM_NPM_VERSION'"
-        echo "[ERROR] Please install an updated version and run npm install again"
+        echo "[ERROR] Please install an updated version and run 'npm install' again"
 	echo "[ERROR] See the README for details"
         exit 1;
 fi

--- a/build/scripts/configure.sh
+++ b/build/scripts/configure.sh
@@ -13,7 +13,7 @@ MINIMUM_NPM_VERSION="6.0.0"
 CURRENT_NPM_VERSION=$(npm -v)
 
 
-version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != $
+version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
 if version_check $CURRENT_NPM_VERSION $MINIMUM_NPM_VERSION; then
         echo "[ERROR] NPM version '$CURRENT_NPM_VERSION' is below requirement of '$MINIMUM_NPM_VERSION'"
         echo "[ERROR] Please install an updated version and run npm install again"

--- a/build/scripts/install.sh
+++ b/build/scripts/install.sh
@@ -11,18 +11,6 @@ set -e
 
 FLAG_PRESERVE_DATA=0;
 
-# Check if NPM is proper version
-MINIMUM_NPM_VERSION="6.0.0"
-CURRENT_NPM_VERSION=$(npm -v)
-
-
-version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
-if version_check $CURRENT_NPM_VERSION $MINIMUM_NPM_VERSION; then
-	echo "[ERROR] NPM version '$CURRENT_NPM_VERSION' is below requirement of '$MINIMUM_NPM_VERSION'"
-	echo "[ERROR] Please install an updated version. See the README for details."
-	exit 1;
-fi
-
 # Check that the APACHE_SITES directory exists.
 if [ ! -d "$APACHE_SITES" ]; then
 	echo "[ERROR] '$APACHE_SITES' doesn't exist.";

--- a/build/scripts/install.sh
+++ b/build/scripts/install.sh
@@ -11,6 +11,18 @@ set -e
 
 FLAG_PRESERVE_DATA=0;
 
+# Check if NPM is proper version
+MINIMUM_NPM_VERSION="6.0.0"
+CURRENT_NPM_VERSION=$(npm -v)
+
+
+version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
+if version_check $CURRENT_NPM_VERSION $MINIMUM_NPM_VERSION; then
+	echo "[ERROR] NPM version '$CURRENT_NPM_VERSION' is below requirement of '$MINIMUM_NPM_VERSION'"
+	echo "[ERROR] Please install an updated version. See the README for details."
+	exit 1;
+fi
+
 # Check that the APACHE_SITES directory exists.
 if [ ! -d "$APACHE_SITES" ]; then
 	echo "[ERROR] '$APACHE_SITES' doesn't exist.";


### PR DESCRIPTION
Simple check to see if NPM is above a certain version during "make configure" step. Required version is stored as a variable and can be altered as needed. Tested on Ubuntu 18.04.

Note: 
Newest available NPM version on Ubuntu/Debian APT is 3.5.2. It does not work. 
Current version is 6.4.1. It does work.
I chose 6.0.0 as an arbitrary cutoff. If there is a known minimum working version, it should be set to that instead.