### PR TITLE
Next

### DIFF
--- a/build/scripts/gcc_version.sh
+++ b/build/scripts/gcc_version.sh
@@ -1,0 +1,9 @@
+CURRENT_GCC_VERSION=$(gcc -dumpfullversion)
+version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1 )" != "$1"; }
+if version_check $CURRENT_GCC_VERSION $1; then
+	echo "0"
+	exit 0
+else
+	echo "1"
+	exit 1
+fi

--- a/build/scripts/gcc_version.sh
+++ b/build/scripts/gcc_version.sh
@@ -1,9 +1,0 @@
-CURRENT_GCC_VERSION=$(gcc -dumpfullversion)
-version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1 )" != "$1"; }
-if version_check $CURRENT_GCC_VERSION $1; then
-	echo "0"
-	exit 0
-else
-	echo "1"
-	exit 1
-fi

--- a/build/scripts/make_version.sh
+++ b/build/scripts/make_version.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+## Compare current version of make to required version (passed as argument)
+
+set -e
+CURRENT_MAKE_VERSION=$(make -v | cut -d " " -f 3 | head -n 1)
+version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1 )" \
+	!= "$1"; }
+if version_check $CURRENT_MAKE_VERSION $1; then
+	echo "[ERROR] Make version $1 required. Please update."
+	exit 1
+else
+	exit 0
+fi

--- a/build/scripts/npm_version.sh
+++ b/build/scripts/npm_version.sh
@@ -1,0 +1,10 @@
+
+CURRENT_NPM_VERSION=$(npm -v)
+version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1 )" != "$1"; }
+if version_check $CURRENT_NPM_VERSION $1; then
+	echo "0"
+	exit 0
+else
+	echo "1"
+	exit 1
+fi

--- a/build/scripts/npm_version.sh
+++ b/build/scripts/npm_version.sh
@@ -1,10 +1,11 @@
-
+#! /bin/sh
+## Compare NPM version to required (passed as argument)
 CURRENT_NPM_VERSION=$(npm -v)
-version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1 )" != "$1"; }
+version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1 )" \
+	!= "$1"; }
 if version_check $CURRENT_NPM_VERSION $1; then
-	echo "0"
-	exit 0
-else
-	echo "1"
+	echo "[ERROR] NPM version $1 unsupported. Please update."
 	exit 1
+else
+	exit 0
 fi

--- a/build/scripts/npm_version.sh
+++ b/build/scripts/npm_version.sh
@@ -4,7 +4,7 @@ CURRENT_NPM_VERSION=$(npm -v)
 version_check () { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1 )" \
 	!= "$1"; }
 if version_check $CURRENT_NPM_VERSION $1; then
-	echo "[ERROR] NPM version $1 unsupported. Please update."
+	echo "[ERROR] NPM version $1 required. Please update."
 	exit 1
 else
 	exit 0

--- a/makefile
+++ b/makefile
@@ -86,7 +86,7 @@ endif
 
 .PHONY: initchk configure dirs server js css api \
 		config libs docs htmldocs install utest \
-		clean realclean LOC VERSION_CHECK
+		clean realclean LOC
 .ONESHELL:
 # Targets only defined if requirements met
 ifeq ($(REQUIREMENTS_MET),1)

--- a/makefile
+++ b/makefile
@@ -11,14 +11,9 @@ ROOT := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 SASS_IPATHS := $(ROOT) $(ROOT)src/common/css $(ROOT)/src/node_modules
 SASSFLAGS := --no-source-map
 
-# Initial Requirement Checks.
+# Define required versions.
 export NPM_REQUIRED_VERSION := 6.4.0
-export GCC_REQUIRED_VERSION := 4.0
-export NPM_VERSION_PASS := $(shell $(ROOT)build/scripts/npm_version.sh $(NPM_REQUIRED_VERSION))
-export GCC_VERSION_PASS := $(shell $(ROOT)build/scripts/gcc_version.sh $(GCC_REQUIRED_VERSION))
-$(info NPM_Version_Pass $(NPM_VERSION_PASS))
-$(info GCC_Version_Pass $(GCC_VERSION_PASS))
-export REQUIREMENTS_MET := $(shell expr $(NPM_VERSION_PASS) \* $(GCC_VERSION_PASS))
+export MAKE_REQUIRED_VERSION := 4.0
 
 # Caller supplied build settings.
 VERBOSE ?= Y
@@ -88,8 +83,6 @@ endif
 		config libs docs htmldocs install utest \
 		clean realclean LOC
 .ONESHELL:
-# Targets only defined if requirements met
-ifeq ($(REQUIREMENTS_MET),1)
 
 all:: server docs htmldocs js css api libs; @:
 server:: initchk $(subst src,dist,$(SRC_NO_COMPILE)); @:
@@ -101,20 +94,6 @@ htmldocs:: initchk $(addprefix dist/doc/html/,$(notdir $(SRC_RST:.rst=.html))); 
 css:: initchk $(subst src,dist,$(SRC_SCSS:.scss=.css)); @:
 libs:: initchk $(subst $(ROOT)node_modules/,dist/libs/,$(LIBS)); @:
 
-else
-#Display NPM Required Version
-ifeq ($(NPM_VERSION_PASS),0)
-$(info [ERROR] NPM version must be at least $(NPM_REQUIRED_VERSION))
-endif
-#Display GCC Required Version
-ifeq ($(GCC_VERSION_PASS),0)
-$(info [ERROR] GCC version must be at least $(GCC_REQUIRED_VERSION))
-endif
-#Halt
-$(error Requirements not met)
-
-endif
-# End of code blocked by requirements
 
 # Copy over non-compiled, non-PHP sources.
 $(filter-out %.php,$(subst src,dist,$(SRC_NO_COMPILE))):: dist%: src%
@@ -406,7 +385,9 @@ initchk:
 	@:
 	set -e
 	./build/scripts/ldconf.sh $(CONF)
-
+	./build/scripts/npm_version.sh $(NPM_REQUIRED_VERSION)
+	./build/scripts/make_version.sh $(MAKE_REQUIRED_VERSION)
+	
 %:
 	@:
 	set -e


### PR DESCRIPTION
As per our previous discussion:

This is not as graceful as I would like, but makefiles aren't as flexible as I'm used to. I also tried to use the same style you did for error messages and code, but please advise if they need to be changed.

The requirements are directly taken from the current README. Makefile tested on Ubuntu 18.04. 

This system adds two shell scripts to the build/scripts directory and uses the ROOT variable to reference them. I believe this is correct, and it does work, but let me know if I misunderstand.

There is now a requirement for expr to be installed. It is my understanding this is a part of POSIX and universally installed. If this is not the case, I can use nested ifs to change the requirement, but this system allows for easier integration of other requirements at a later date.

It is also possible to put all of the requirements in a single script that is called for a single pass/fail state, but this would make delivering useful error messages more difficult.

Let me know if any other changes are required.