### PR TITLE
Added naive method for automating login

### DIFF
--- a/src/login/js/main.js
+++ b/src/login/js/main.js
@@ -17,4 +17,25 @@ $(document).ready(async () => {
 
 	let view = new LoginView(API);
 	view.init();
+
+	document.querySelector('#input-user').value=getParams().user || '';
+	document.querySelector('#input-pass').value=getParams().pass || '';
+	if( getParams().user && getParams().pass ) {
+		document.querySelector('#btn-login').disabled = false;
+		document.querySelector('#btn-login').click();
+	}
 });
+
+function getParams(url) {
+	url = url || window.location.href;
+	var params = {};
+	var parser = document.createElement('a');
+	parser.href = url;
+	var query = parser.search.substring(1);
+	var vars = query.split('&');
+	for (var i = 0; i < vars.length; i++) {
+		var pair = vars[i].split('=');
+		params[pair[0]] = decodeURIComponent(pair[1]);
+	}
+	return params;
+};


### PR DESCRIPTION
Added some simple JS to allow logging in with URL parameters.

Could not get docker to build on Mac, so not fully tested, nor documented.

Strongly recommend instead supporting basic auth on the serverside, so that instead of `/login/?user=display&pass=foo&redir=...`  it would be `display:foo@` (or hidden in headers).

Hopefully this helps someone in the meantime.

:)